### PR TITLE
feat: add name to user point endpoint response

### DIFF
--- a/api/users/points/index.go
+++ b/api/users/points/index.go
@@ -9,8 +9,8 @@ import (
 )
 
 type UserPoints struct {
-	FirstName string `json:"first_name"`
-	LastName string `json:"last_name"`
+	FirstName string `json:"firstName"`
+	LastName string `json:"lastName"`
 	Points int `json:"points"`
 }
 type Response struct {


### PR DESCRIPTION
### Notes
- Add `first_name` and `last_name` to `/v1/users/points` endpoint response
   - Need for discord bot `/points` command, the command needs to display a user's name and their points

### Screenshots
<img width="616" alt="Screen Shot 2023-12-11 at 11 20 45 PM" src="https://github.com/codecoogs/gogo/assets/91701930/8867d0c5-ddbf-48b6-987f-6d4e84eb0739">

![Screen Shot 2023-12-11 at 11 25 11 PM](https://github.com/codecoogs/gogo/assets/91701930/ad7f35ed-929f-42f7-a52d-939990127495)
