### PR TITLE
fix: add 'omitempty' to userPoints

### DIFF
--- a/api/users/points/index.go
+++ b/api/users/points/index.go
@@ -9,8 +9,8 @@ import (
 )
 
 type UserPoints struct {
-	FirstName string `json:"firstName"`
-	LastName string `json:"lastName"`
+	FirstName string `json:"first_name,omitempty"`
+	LastName string `json:"last_name,omitempty"`
 	Points int `json:"points"`
 }
 type Response struct {


### PR DESCRIPTION
### Notes
- Change camelCase back to snake_case in `UserPoints` struct
- Add 'omitempty' to `UserPoints` struct because it would make first name and last name both empty string when making a `PATCH` request to the endpoint. Example,

When making this `PATCH` request:
<img width="650" alt="Screen Shot 2023-12-12 at 12 57 29 AM" src="https://github.com/codecoogs/gogo/assets/91701930/be87d3dd-1bd1-4ade-84ae-a72c5b7c9b4d">

A `GET` request would result in this:
<img width="608" alt="Screen Shot 2023-12-12 at 12 58 52 AM" src="https://github.com/codecoogs/gogo/assets/91701930/fb91697a-0339-4053-8f43-f3212ec63e74">

But by adding 'omitempty', we can update a user's points without it being changed to an empty string. Running the same `PATCH` request and then a `GET` request results in this:
<img width="625" alt="Screen Shot 2023-12-12 at 1 02 28 AM" src="https://github.com/codecoogs/gogo/assets/91701930/087305ce-3e0b-4c15-828c-93d8542e8cf4">
