### PR TITLE
feat: return all todos

### DIFF
--- a/api/todos/index.go
+++ b/api/todos/index.go
@@ -6,7 +6,7 @@ import (
 	"github.com/codecoogs/gogo/wrappers/http"
 	"github.com/codecoogs/gogo/wrappers/supabase"
 	"github.com/codecoogs/gogo/constants"
-
+	"github.com/supabase/postgrest-go"
 )
 
 type Todo struct {
@@ -46,8 +46,13 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	if id == "" {
 		switch r.Method {
 		case "GET":
+			var MyOrderOpts = &postgrest.OrderOpts{
+				Ascending:    true,
+				NullsFirst:   false,
+				ForeignTable: "",
+			}
 			var todo []Todo
-			if _, err := client.From(constants.TODO_TABLE).Select("*", "exact", false).ExecuteTo(&todo); err != nil {
+			if _, err := client.From(constants.TODO_TABLE).Select("*", "exact", false).Order("deadline", MyOrderOpts).ExecuteTo(&todo); err != nil {
 				crw.SendJSONResponse(http.StatusInternalServerError, Response{
 					Success: false,
 					Error: &ErrorDetails{


### PR DESCRIPTION
### Notes
- Add GET request to `/v1/todos` that returns all todos
    - Todos are returned sorted by the earliest deadline

### Screenshots
<img width="1135" alt="Screen Shot 2024-02-01 at 10 45 52 PM" src="https://github.com/codecoogs/gogo/assets/91701930/adcd89c8-856c-4cab-b0f7-268c61b8b774">
<img width="1093" alt="Screen Shot 2024-02-01 at 10 46 11 PM" src="https://github.com/codecoogs/gogo/assets/91701930/c2c6a08a-9278-451c-be67-879f3e5424ef">
