### PR TITLE
fix: add todo with id 0

### DIFF
--- a/api/todos/index.go
+++ b/api/todos/index.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Todo struct {
-	ID        int    `json:"id"`
+	ID        int    `json:"id,omitempty"`
 	Title     string `json:"title"`
 	Deadline  string `json:"deadline"`
 	Completed bool   `json:"completed"`


### PR DESCRIPTION
### Notes
- I recently removed `omitempty` from `ID` in `Todo` struct, but the problem with this was that when someone makes a POST request to add a new todo, `id` would **always** be 0 (since it did not omit if empty). Supabase should automatically assign a sequential unique number to `id` on the `Todo` table.