### PR TITLE
fix: omit empty user id

### DIFF
--- a/api/users/index.go
+++ b/api/users/index.go
@@ -10,7 +10,7 @@ import (
 )
 
 type User struct {
-	ID                 uuid.UUID  `json:"id"`
+	ID                 *uuid.UUID  `json:"id,omitempty"`
 	FirstName          string     `json:"first_name"`
 	LastName           string     `json:"last_name"`
 	Email              string     `json:"email"`


### PR DESCRIPTION
### Notes
- Add omit empty to `id` in the `User` struct because we shouldn't need to pass in a UUID when creating a new user, we should let Supabase handle that.