### PR TITLE
fix: add omit empty all ids

### DIFF
--- a/api/events/index.go
+++ b/api/events/index.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Event struct {
-	ID          uuid.UUID  `json:"id"`
+	ID          *uuid.UUID  `json:"id,omitempty"`
 	Type        string     `json:"type"`
 	StartTime   string     `json:"start_time"`
 	EndTime     string     `json:"end_time"`

--- a/api/leaderboards/index.go
+++ b/api/leaderboards/index.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Leaderboard struct {
-	ID   int    `json:"id"`
+	ID   *int    `json:"id,omitempty"`
 	Name string `json:"name"`
 }
 

--- a/api/payments/index.go
+++ b/api/payments/index.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Payment struct {
-	ID          uuid.UUID `json:"id"`
+	ID          *uuid.UUID `json:"id,omitempty"`
 	Payer       uuid.UUID `json:"payer"`
 	Payee       uuid.UUID `json:"payee"`
 	Name        string    `json:"name"`

--- a/api/teams/index.go
+++ b/api/teams/index.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Team struct {
-	ID     uuid.UUID `json:"id"`
+	ID     *uuid.UUID `json:"id,omitempty"`
 	Name   string    `json:"name"`
 	Points int       `json:"points"`
 }

--- a/api/todos/index.go
+++ b/api/todos/index.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Todo struct {
-	ID        int    `json:"id,omitempty"`
+	ID        *int    `json:"id,omitempty"`
 	Title     string `json:"title"`
 	Deadline  string `json:"deadline"`
 	Completed bool   `json:"completed"`


### PR DESCRIPTION
### Notes
- Add `omitempty` to `id` in event, leaderboard, payments, teams, and todos creation. We shouldn't need to specify the UUID's  or integer values of these attributes, supabase will handle this.