### PR TITLE
fix: change leaderboard id type

### DIFF
--- a/api/leaderboards/index.go
+++ b/api/leaderboards/index.go
@@ -6,11 +6,12 @@ import (
 	"github.com/codecoogs/gogo/wrappers/supabase"
 	"github.com/codecoogs/gogo/constants"
 	"net/http"
+	"github.com/google/uuid"
 )
 
 type Leaderboard struct {
-	ID   *int    `json:"id,omitempty"`
-	Name string `json:"name"`
+	ID   *uuid.UUID `json:"id,omitempty"`
+	Name string     `json:"name"`
 }
 
 type Response struct {


### PR DESCRIPTION
### Notes
- Change leaderboard ID type from integer to UUID, following API Design.

### Screenshots
<img width="411" alt="Screen Shot 2024-02-10 at 3 58 08 PM" src="https://github.com/codecoogs/gogo/assets/91701930/a5ee9657-c79a-41f4-bdf2-a7c43a1659ca">
